### PR TITLE
Require "composer-packages" when composer.json is present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /build
 /bin/
 *.tgz
+.idea/

--- a/README.md
+++ b/README.md
@@ -6,10 +6,13 @@ PHP apps.
 
 ## Behavior
 
-This buildpack will always participate if it's `requirements` are met. In the
+This buildpack will always participate if its `requirements` are met. In the
 HTTPD server case `requires` `php`, `php-fpm` optionally, `httpd`, and
 `php-httpd-config`. In the Nginx case, it will require `nginx` and `php-nginx-config`
 instead of `httpd` and `php-httpd-config`.
+
+In either the HTTPD server or Nginx case, this buildpack will require
+`composer-packages` when a `composer.json` file is available.
 
 When this buildpack runs, the `PHP_HTTPD_PATH` OR the `PHP_NGINX_PATH`
 environment variable must be set  by another buildpack in conjunction with
@@ -21,12 +24,12 @@ conjunction with the other buildpacks in the Paketo PHP language family.
 Because of this, the usage of this buildpack is fairly tightly coupled to other
 buildpacks in the PHP language family.
 
-
-| Requirement        | Build | Launch |
-|--------------------|-------|--------|
-| `php`              | x     |        |
-| `php-fpm`          | x     | x      |
-| `httpd` or `nginx` | x     |        |
+| Requirement                      | Build | Launch |
+|----------------------------------|-------|--------|
+| `php`                            | x     |        |
+| `composer-packages`              |       | x      |
+| `php-fpm`                        | x     | x      |
+| `httpd` or `nginx`               | x     |        |
 | `httpd-config` or `nginx-config` | x     | x      |
 
 It will set the default start command to something that looks like:

--- a/detect.go
+++ b/detect.go
@@ -1,7 +1,11 @@
 package phpstart
 
 import (
+	"os"
+	"path/filepath"
+
 	"github.com/paketo-buildpacks/packit/v2"
+	"github.com/paketo-buildpacks/packit/v2/fs"
 )
 
 // BuildPlanMetadata is the buildpack specific data included in build plan
@@ -47,6 +51,23 @@ func Detect() packit.DetectFunc {
 					Launch: true,
 				},
 			},
+		}
+
+		composerJsonPath := filepath.Join(context.WorkingDir, "composer.json")
+
+		if value, found := os.LookupEnv("COMPOSER"); found {
+			composerJsonPath = filepath.Join(context.WorkingDir, value)
+		}
+
+		if exists, err := fs.Exists(composerJsonPath); err != nil {
+			return packit.DetectResult{}, err
+		} else if exists {
+			baseRequirements = append(baseRequirements, packit.BuildPlanRequirement{
+				Name: "composer-packages",
+				Metadata: BuildPlanMetadata{
+					Launch: true,
+				},
+			})
 		}
 
 		httpdFpmPlan := packit.BuildPlan{

--- a/detect_test.go
+++ b/detect_test.go
@@ -2,13 +2,14 @@ package phpstart_test
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
 	"github.com/paketo-buildpacks/packit/v2"
 	phpstart "github.com/paketo-buildpacks/php-start"
 	"github.com/sclevine/spec"
-
-	. "github.com/onsi/gomega"
 )
 
 func testDetect(t *testing.T, context spec.G, it spec.S) {
@@ -101,5 +102,71 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 				},
 			}))
 		})
+
+		context("composer", func() {
+			context("with composer.json", func() {
+				it.Before(func() {
+					Expect(os.WriteFile(filepath.Join(workingDir, "composer.json"), []byte(""), os.ModePerm)).To(Succeed())
+				})
+
+				it("requires composer-packages at launch", func() {
+					result, err := detect(packit.DetectContext{
+						WorkingDir: workingDir,
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(result.Plan.Requires).To(ContainElements(packit.BuildPlanRequirement{
+						Name: "composer-packages",
+						Metadata: phpstart.BuildPlanMetadata{
+							Launch: true,
+						},
+					}))
+				})
+			})
+
+			context("with $COMPOSER", func() {
+				it.Before(func() {
+					Expect(os.Setenv("COMPOSER", "some/other-file.json")).To(Succeed())
+				})
+
+				it.After(func() {
+					Expect(os.Unsetenv("COMPOSER")).To(Succeed())
+				})
+
+				context("that points to an existing file", func() {
+					it.Before(func() {
+						Expect(os.Mkdir(filepath.Join(workingDir, "some"), os.ModeDir|os.ModePerm)).To(Succeed())
+						Expect(os.WriteFile(filepath.Join(workingDir, "some", "other-file.json"), []byte(""), os.ModePerm)).To(Succeed())
+					})
+
+					it("requires composer-packages at launch", func() {
+						result, err := detect(packit.DetectContext{
+							WorkingDir: workingDir,
+						})
+						Expect(err).NotTo(HaveOccurred())
+
+						Expect(result.Plan.Requires).To(ContainElements(packit.BuildPlanRequirement{
+							Name: "composer-packages",
+							Metadata: phpstart.BuildPlanMetadata{
+								Launch: true,
+							},
+						}))
+					})
+				})
+
+				context("that points to a non existing file", func() {
+					it("does not require composer-packages", func() {
+						result, err := detect(packit.DetectContext{
+							WorkingDir: workingDir,
+						})
+						Expect(err).NotTo(HaveOccurred())
+
+						Expect(result.Plan.Requires).ToNot(ContainElements(MatchFields(IgnoreExtras, Fields{
+							"Name": Equal("composer-packages"),
+						})))
+					})
+				})
+			})
+		}, spec.Sequential())
 	})
 }


### PR DESCRIPTION
## Summary
Resolve #16 

## Use Cases
Require "composer-packages" when composer.json is present

Note: I chose not to include an integration test here, for several reasons:
- I suspect the `composer-install` and/or language family buildpacks will have their own integration tests specific to Composer use cases
- The `composer` and `composer-install` buildpacks have not yet been released

## Checklist
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
